### PR TITLE
Fix compute uts, add special case for compute advantages

### DIFF
--- a/model/compute/advantages.py
+++ b/model/compute/advantages.py
@@ -5,6 +5,10 @@ from torch import Tensor
 Computes the normalized advantage of the model's answer
 """
 def compute_advantages(args: AZRArgs, rewards: Float[Tensor, "role task minibatch_size"]) -> Float[Tensor, "role task minibatch_size"]:
+    # If we only have one item in the last dimension, just return the rewards directly
+    if rewards.size(-1) == 1:
+        return rewards
+    
     # normalize each reward for each role and task by subtracting the mean and dividing by the standard deviation
     rewards -= rewards.mean(dim=-1, keepdim=True)
     rewards /= (rewards.std(dim=-1, keepdim=True) + args.eps)  # add a small constant to avoid division by zero

--- a/tests/test_advantages.py
+++ b/tests/test_advantages.py
@@ -50,9 +50,9 @@ class TestComputeAdvantages:
         ])
         
         advantages = compute_advantages(args, rewards)
-        
-        # When std=0, the normalization should handle it gracefully with eps
-        assert torch.all(advantages == 0.0), "Single values should result in 0 advantages"
+
+        # When minibatch_size=1, we should get back the original rewards
+        assert torch.all(advantages == rewards), "Single values should return original rewards"
     
     def test_compute_advantages_identical_rewards(self, args):
         """Test when all rewards are identical (std=0)."""
@@ -82,10 +82,10 @@ class TestComputeAdvantages:
         
         small_advantages = compute_advantages(args, small_rewards)
         
-        # Test with very large rewards
+        # Test with very large rewards - use float values to avoid int tensor issues
         large_rewards = torch.tensor([
-            [[1000, 2000, 3000, 4000]],
-            [[10000, 20000, 30000, 40000]]
+            [[1000.0, 2000.0, 3000.0, 4000.0]],
+            [[10000.0, 20000.0, 30000.0, 40000.0]]
         ])
         
         large_advantages = compute_advantages(args, large_rewards)


### PR DESCRIPTION
This pull request introduces updates to the `compute_advantages` function, enhances test coverage for edge cases, and refactors the `compute_r_total` tests to improve clarity and correctness. Key changes include handling single-item edge cases in advantage computation, refining test logic, and updating mock behavior for reward computation tests.

### Changes to `compute_advantages`:

* Added a condition to return rewards directly when the last dimension has only one item, improving edge case handling in the `compute_advantages` function (`model/compute/advantages.py`).
* Updated the test `test_compute_advantages_single_value` to assert that single-item rewards return the original rewards instead of being normalized to zero (`tests/test_advantages.py`).
* Adjusted test `test_compute_advantages_different_scales` to use float values for large rewards, preventing issues with integer tensors (`tests/test_advantages.py`).

### Changes to `compute_r_total` tests:

* Replaced `validate_formatting_and_correctness` with `validate_solver_formatting_and_correctness` in multiple tests to align with updated validation logic (`tests/test_rewards.py`). [[1]](diffhunk://#diff-997ffcd56d32decb6d80b310a4f80fc1041b50b6d9a39fa6a8d46c0630b7e449L73-R73) [[2]](diffhunk://#diff-997ffcd56d32decb6d80b310a4f80fc1041b50b6d9a39fa6a8d46c0630b7e449L95-R111) [[3]](diffhunk://#diff-997ffcd56d32decb6d80b310a4f80fc1041b50b6d9a39fa6a8d46c0630b7e449L115-R134) [[4]](diffhunk://#diff-997ffcd56d32decb6d80b310a4f80fc1041b50b6d9a39fa6a8d46c0630b7e449L136-R145) [[5]](diffhunk://#diff-997ffcd56d32decb6d80b310a4f80fc1041b50b6d9a39fa6a8d46c0630b7e449L161-R193)
* Introduced mock samples in various `compute_r_total` tests to simulate responses and ensure the validation function is called with the correct parameters (`tests/test_rewards.py`). [[1]](diffhunk://#diff-997ffcd56d32decb6d80b310a4f80fc1041b50b6d9a39fa6a8d46c0630b7e449R82-R88) [[2]](diffhunk://#diff-997ffcd56d32decb6d80b310a4f80fc1041b50b6d9a39fa6a8d46c0630b7e449L95-R111) [[3]](diffhunk://#diff-997ffcd56d32decb6d80b310a4f80fc1041b50b6d9a39fa6a8d46c0630b7e449L115-R134) [[4]](diffhunk://#diff-997ffcd56d32decb6d80b310a4f80fc1041b50b6d9a39fa6a8d46c0630b7e449R154-R160) [[5]](diffhunk://#diff-997ffcd56d32decb6d80b310a4f80fc1041b50b6d9a39fa6a8d46c0630b7e449L161-R193)